### PR TITLE
chore!: ship ESM only, require node 22.12

### DIFF
--- a/.changeset/nervous-pianos-repeat.md
+++ b/.changeset/nervous-pianos-repeat.md
@@ -1,0 +1,17 @@
+---
+"@portabletext/react-pdf": major
+---
+
+The package is now ESM only, and requires Node.js 22.12 or later
+
+#### When you will see a difference
+
+Only if you load this package with `require()`, or build on Node.js 20 or earlier. If you already `import` it, nothing changes.
+
+#### What changes
+
+The package no longer ships a CommonJS build. `require("@portabletext/react-pdf")` will fail, where before it resolved to `dist/index.cjs`. Use `import` instead, or a dynamic `await import()` from a CommonJS file.
+
+This brings the package in line with the rest of the Portable Text packages, which are already ESM only.
+
+Node.js 20 reached end of life in April 2026. The package previously declared no `engines` range at all, so nothing was enforced.

--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
 		".": {
 			"source": "./src/index.ts",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs",
 			"default": "./dist/index.js"
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.js",
+	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
 		"dist",
@@ -96,6 +94,9 @@
 		"typescript-eslint": "^8.41.0",
 		"vite": "^7.1.3",
 		"vitest": "^3.2.4"
+	},
+	"engines": {
+		"node": ">=22.12"
 	},
 	"packageManager": "pnpm@10.11.1",
 	"publishConfig": {


### PR DESCRIPTION
Brings this package in line with the rest of the Portable Text packages, which are already ESM only on Node.js 22.12 or later. It was the one that got missed.

## Changes

- Dropped the CommonJS build. The `require` condition is gone from `exports`, `main` now points at the ESM entry, and `module` is removed as redundant under `"type": "module"`. `pkg-utils` no longer emits `dist/index.cjs`.
- Added `engines.node: ">=22.12"`. There was no `engines` range at all before, so nothing was enforced.

`pkg-utils build --strict` requires `main` to be declared, which is why it points at `dist/index.js` here rather than being removed the way it was in `@portabletext/toolkit`.

## Breaking

`require("@portabletext/react-pdf")` no longer resolves. Use `import`, or a dynamic `await import()` from a CommonJS file.

## Verification

47 tests pass, lint and type-check clean, and the build output is a single ESM entry with no `.cjs`.

## Unrelated, but worth knowing

While checking whether the `nestLists()` fix in `@portabletext/toolkit@6.0.0` affects this package, I rendered lists that start deeper than level 1 and lists that skip levels, which the fixtures here do not currently cover. **No code changes are needed.** The output is correct: a level 3 opener gets its roman numeral, indentation follows the item's own `level`, and the generated intermediate levels draw no markers because `direct` mode fills them with item-less lists and `listDeep` carries no margin.

Two things did come up:

- The dependencies here are a long way behind. `@portabletext/react` is on `^3.2.4` against a current 7.0.1, with an 8.0.0 pending in portabletext/react-portabletext#340, and the type-only `@portabletext/toolkit` dep is on `^3.0.0` against 6.0.0. Worth planning separately.
- No fixture covers a list that starts deeper than level 1. Since CI runs macOS only, a fixture plus a darwin snapshot would work here if you want the coverage.
